### PR TITLE
fixed bug with hot-cache key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Text editor files
+*.swp

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,7 +54,7 @@ func Cache(w http.ResponseWriter, r *http.Request) {
 	}
 
 	n, err := io.Copy(w, rcs)
-	log.Printf("%v bytes written for uri %q err %v\n", n, uri, err)
+	log.Printf("%v bytes sent out for uri %q err %v\n", n, uri, err)
 	_ = rcs.Close()
 }
 


### PR DESCRIPTION
Fixes #1.

This PR fixes a bug in which the key for items that are entered
hot (ie not during disk discovery but dynamically during requests)
was using the raw URI instead of the fsTranslated key.
