### PR TITLE
updates: http2-http1 toggle, send warning + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,14 @@
 Cache web and other resources locally
 
 ## Running it
-+ See cmd/server/main.go
++ See cmd/cachy-server/main.go
+
+## Install it
+```shell
+$ go get github.com/odeke-em/cachy/cmd/cachy-server && cachy-server
+```
+
+## Env variables to set
+- CACHY_SERVER_ADDRESS
+- CACHY_CERT_FILE
+- CACHY_KEY_FILE


### PR DESCRIPTION
- Switch between http2 and http1 by using env flag `http1=`.
- Send warning if `uri` is not found in postForm.
- Update README to show variables to set as well as how to install.
- Renamed s/cmd\/server/cmd\/cachy-server/
